### PR TITLE
postinstall macOS: check if Finder is running

### DIFF
--- a/admin/osx/post_install.sh.cmake
+++ b/admin/osx/post_install.sh.cmake
@@ -1,12 +1,16 @@
 #!/bin/sh
 
-osascript << EOF
+# Check if Finder is running (for systems with Finder disabled)
+finder_status=`ps aux | grep "/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder" | grep -v "grep"`
+if ! [ "$finder_status" == "" ] ; then # Finder is running
+   osascript << EOF
 tell application "Finder"
    activate
    select the last Finder window
 	reveal POSIX file "/Applications/@APPLICATION_EXECUTABLE@.app"
 end tell
 EOF
+fi
 
 # Always enable the new 10.10 finder plugin if available
 if [ -x "$(command -v pluginkit)" ]; then


### PR DESCRIPTION
Some users have disabled Finder, and the postinstall will always reenable Finder, unless it checks Finder status first.